### PR TITLE
Fixed term size detection using stty on OS X

### DIFF
--- a/src/Output/Tty.php
+++ b/src/Output/Tty.php
@@ -44,6 +44,10 @@ class Tty extends Simple
 
         preg_match('/rows (\d+); columns (\d+)/', $sttyOutput[0], $matches);
 
+        if (count($matches) < 2) {
+            preg_match('/(\d+) rows; (\d+) columns/', $sttyOutput[0], $matches);
+        }
+
         $this->rows = $matches[1];
         $this->columns = $matches[2];
     }


### PR DESCRIPTION
`stty -a` output is not consistent, at least on OS X. This PR attempts to mitigate this issue and still return valid terminal dimensions.