### PR TITLE
Fixed tests order with graph dependencies

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -11,6 +11,8 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 class Pool
 {
+    private $completedTests;
+
     private $tests;
 
     private $runningTests;
@@ -21,6 +23,7 @@ class Pool
 
     public function __construct()
     {
+        $this->completedTests = new ArrayCollection();
         $this->futureTests = new ArrayCollection();
         $this->runningTests = new ArrayCollection();
         $this->futureHttpPool = new FutureHttpPool();
@@ -92,6 +95,7 @@ class Pool
      */
     public function passFinishTest(Test $test)
     {
+        $this->completedTests->add($test);
         $this->runningTests->removeElement($test);
     }
 
@@ -133,6 +137,18 @@ class Pool
     public function countPendingHttp()
     {
         return $this->futureHttpPool->count();
+    }
+
+    /**
+     * Check if a test in the pool has been completed.
+     *
+     * @param Test $test
+     *
+     * @return bool
+     */
+    public function hasCompletedTest(Test $test)
+    {
+        return $this->completedTests->contains($test);
     }
 
     /**

--- a/src/Runner/PoolRunner.php
+++ b/src/Runner/PoolRunner.php
@@ -208,8 +208,9 @@ class PoolRunner
                 $complete = true;
 
                 foreach ($childTest->getParents() as $parentTest) {
-                    if ($pool->hasTest($parentTest)) {
+                    if (!$pool->hasCompletedTest($parentTest)) {
                         $complete = false;
+                        break;
                     }
                 }
 


### PR DESCRIPTION
In the case of dependency graphs, the tests were added to the future tests pool without checking if all the dependency parents have been competed.

This PR ensures that a test is only scheduled when all of its parents have been completed.