### PR TITLE
Allow 3.* version of bovigo/assert

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": "^7.0",
         "amphp/artax": "^3.0.13",
         "amphp/sync": "^1.0",
-        "bovigo/assert": "^2.1",
+        "bovigo/assert": "^2.1||^3.0",
         "doctrine/annotations": "^1.2",
         "doctrine/collections": "^1.3",
         "guzzlehttp/psr7": "^1.4",
@@ -40,5 +40,8 @@
         "symfony/finder": "^3.1",
         "symfony/yaml": "^3.3"
     },
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "sort-packages": true
+    }
 }

--- a/src/Assert/AssertCaseTrait.php
+++ b/src/Assert/AssertCaseTrait.php
@@ -43,6 +43,7 @@ use function bovigo\assert\predicate\{
     isSameAs,
     isTrue,
     matches,
+    matchesFormat,
     startsWith
 };
 use bovigo\assert\predicate\Predicate;
@@ -538,6 +539,22 @@ trait AssertCaseTrait
     public function assertStringEndsNotWith($suffix, $string, $message = null)
     {
         $this->assert($string, doesNotEndWith($suffix), $message);
+    }
+
+    /**
+     * Asserts that a string matches a given format string.
+     *
+     * @param string $format
+     * @param string $string
+     * @param string $message
+     */
+    public function assertStringMatchesFormat($format, $string, $message = '')
+    {
+        if (!function_exists('bovigo\assert\predicate\matchesFormat')) {
+            throw new \Exception('The "matchesFormat" assertion exists since bovigo/assert 3.2. Please upgrade the library before using this function.');
+        }
+
+        $this->assert($string, matchesFormat($format), $message);
     }
 
     /**


### PR DESCRIPTION
I need new features that lives in `3.*` but asynit blocks to `2.*`.
I can not bump to `3.*` as there is a BC break https://github.com/mikey179/bovigo-assert/releases/tag/v3.0.0  