### PR TITLE
Declare vars before using it

### DIFF
--- a/src/Parser/TestsFinder.php
+++ b/src/Parser/TestsFinder.php
@@ -25,6 +25,8 @@ class TestsFinder
 
     private function doFindTests($files): array
     {
+        $methods = [];
+
         foreach ($files as $file) {
             $existingClasses = get_declared_classes();
             $path = $file;


### PR DESCRIPTION
If there are not tests, then an exception occurs:

```
PHP Notice:  Undefined variable: methods in PROJECT/vendor/jolicode/asynit/src/Parser/TestsFinder.php on line 56
PHP Fatal error:  Uncaught TypeError: Return value of Asynit\Parser\TestsFinder::doFindTests() must be of the type array, null returned in PROJECT/vendor/jolicode/asynit/src/Parser/TestsFinder.php:56
Stack trace:
#0 PROJECT/vendor/jolicode/asynit/src/Parser/TestsFinder.php(14): Asynit\Parser\TestsFinder->doFindTests(Array)
#1 PROJECT/vendor/jolicode/asynit/src/Command/AsynitCommand.php(62): Asynit\Parser\TestsFinder->findTests('Api/UserOrganiz...')
#2 PROJECT/vendor/symfony/console/Command/Command.php(252): Asynit\Command\AsynitCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 PROJECT/vendor/symfony/console/Application.php(938): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 PROJECT/vendor/symfony/console/Application.php(240): Symfony\Component\Console\Application->doRunCo in PROJECT/vendor/jolicode/asynit/src/Parser/TestsFinder.php on line 56
```