### PR TITLE
Allowed status configuration to be an array of status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ suite and will leverage the cache system.
 Smoker use the Asynit API to provide a simple way to test many URLs when there
 is no need to have a complex logic of testing.
 
+You can pass a status code or an array of status code that will be considered valid.
+
 You just have to define a YAML file like the following:
 
 ```yaml
@@ -268,7 +270,7 @@ You just have to define a YAML file like the following:
     status: 200
 
 "https://jolicode.com/equipe":
-    status: 200
+    status: [200, 302]
 
 "https://jolicode.com/nos-valeurs":
     status: 200

--- a/src/SmokerTestCase.php
+++ b/src/SmokerTestCase.php
@@ -19,7 +19,11 @@ class SmokerTestCase extends TestCase
 
         $response = yield $this->get($uri);
 
-        static::assertStatusCode($configuration['status'], $response);
+        if (is_array($configuration['status'])) {
+            static::assertContains($response->getStatusCode(), $configuration['status']);
+        } else {
+            static::assertStatusCode($configuration['status'], $response);
+        }
 
         if (!isset($configuration['discovery'])) {
             return;


### PR DESCRIPTION
Useful if you don't care about if tested URLs respond 200 or 302