### PR TITLE
Fix code for PHP 8.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 
 php:
     - 7.4
+    - 8.0
 
 matrix:
     fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "test": "bin/asynit tests/"
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "amphp/http-client": "^3.0.14",
         "amphp/sync": "^1.0",
         "bovigo/assert": "^6.2",


### PR DESCRIPTION
the code is broken because of https://3v4l.org/MF8IZ

> The ability to call non-static methods statically has been removed.
Thus is_callable() will fail when checking for a non-static method with
a classname (must check with an object instance).

https://www.php.net/manual/fr/migration80.incompatible.php