### PR TITLE
Fix typo

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -41,7 +41,7 @@ class Pool
         return $this->tests;
     }
 
-    public function getTestToRun()
+    public function getTestToRun(): ?Test
     {
         foreach ($this->tests as $test) {
             if ($test->canBeRun()) {


### PR DESCRIPTION
Without this patch, if a test has been registered, it may be be retrived
from the current pool. Now, we ensure the take is used.

Without this patch, a project test suite will stop in the middle,
because some tests would never be finished (because tests are
duplicated) so one parent tests is finished whereas its copy is not.