### PR TITLE
Fixed PHP 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "doctrine/annotations": "^1.2",
         "doctrine/collections": "^1.3",
         "guzzlehttp/psr7": "^1.4",
-        "php-http/client-common": "^1.4",
+        "php-http/client-common": "^2.3",
         "php-http/message": "^1.3",
         "symfony/console": "^4.4 || ^5.0",
         "symfony/dom-crawler": "^4.4 || ^5.0",


### PR DESCRIPTION
php-http/client-common was in a too low version which not support PHP 8