### PR TITLE
Fixed --host option in smoker command

### DIFF
--- a/src/Command/SmokerCommand.php
+++ b/src/Command/SmokerCommand.php
@@ -41,7 +41,7 @@ class SmokerCommand extends Command
     {
         // Build the client
         $parser = new SmokeParser();
-        $testMethods = $parser->parse($input->getArgument('file'));
+        $testMethods = $parser->parse($input->getArgument('file'), $input->getOption('host'));
 
         list($chainOutput, $countOutput) = (new OutputFactory())->buildOutput(\count($testMethods));
 

--- a/src/Parser/SmokeParser.php
+++ b/src/Parser/SmokeParser.php
@@ -10,13 +10,14 @@ use Symfony\Component\Yaml\Yaml;
 
 class SmokeParser
 {
-    public function parse($file)
+    public function parse($file, $host)
     {
         $methods = [];
         $contents = file_get_contents($file);
         $data = Yaml::parse($contents);
 
         foreach ($data as $url => $configuration) {
+            $url = $host . $url;
             $test = new SmokeTest(new \ReflectionMethod(SmokerTestCase::class, 'smokeTest'), $url);
             $argument = [$url, $configuration, $test];
             $test->addArgument($argument, $test);


### PR DESCRIPTION
It seems like the `--host` option was unused. This PR fixes it by passing the host to the parser.