### PR TITLE
Add an option to output order of test execution

### DIFF
--- a/src/Command/AsynitCommand.php
+++ b/src/Command/AsynitCommand.php
@@ -34,6 +34,7 @@ class AsynitCommand extends Command
             ->addOption('allow-self-signed-certificate', null, InputOption::VALUE_NONE, 'Allow self signed ssl certificate')
             ->addOption('concurrency', null, InputOption::VALUE_REQUIRED, 'Max number of parallels requests', 10)
             ->addOption('bootstrap', null, InputOption::VALUE_REQUIRED, 'A PHP file to include before anything else', $this->defaultBootstrapFilename)
+            ->addOption('order', null, InputOption::VALUE_NONE, 'Output tests execution order')
         ;
     }
 
@@ -52,7 +53,7 @@ class AsynitCommand extends Command
         $testsFinder = new TestsFinder();
         $testMethods = $testsFinder->findTests($input->getArgument('target'));
 
-        list($chainOutput, $countOutput) = (new OutputFactory())->buildOutput(\count($testMethods));
+        list($chainOutput, $countOutput) = (new OutputFactory($input->getOption('order')))->buildOutput(\count($testMethods));
 
         // Build services for parsing and running tests
         $builder = new TestPoolBuilder(new AnnotationReader());

--- a/src/Output/OutputFactory.php
+++ b/src/Output/OutputFactory.php
@@ -9,12 +9,23 @@ namespace Asynit\Output;
  */
 class OutputFactory
 {
+    private $order = false;
+
+    public function __construct(bool $order = false)
+    {
+        $this->order = $order;
+    }
+
     public function buildOutput(int $testCount): array
     {
         $countOutput = new Count();
         $chainOutput = new Chain();
         $chainOutput->addOutput(new PhpUnitAlike($testCount));
         $chainOutput->addOutput($countOutput);
+
+        if ($this->order) {
+            $chainOutput->addOutput(new OutputOrder());
+        }
 
         return [$chainOutput, $countOutput];
     }

--- a/src/Output/OutputOrder.php
+++ b/src/Output/OutputOrder.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Asynit\Output;
+
+use Asynit\Test;
+
+class OutputOrder implements OutputInterface
+{
+    /** @var Test[] */
+    private $tests = [];
+
+    public function outputStep(Test $test, $debugOutput)
+    {
+    }
+
+    public function outputFailure(Test $test, $debugOutput, $failure)
+    {
+        $this->tests[] = $test;
+    }
+
+    public function outputSuccess(Test $test, $debugOutput)
+    {
+        $this->tests[] = $test;
+    }
+
+    public function outputSkipped(Test $test, $debugOutput)
+    {
+    }
+
+    public function __destruct()
+    {
+        fwrite(STDOUT, "\nTest orders:\n\n");
+
+        $orders = [];
+
+        foreach ($this->tests as $index => $test) {
+            $depends = $this->createDepends($test, $orders);
+            $orders[$test->getDisplayName()] = $index;
+            $dependsStr = "";
+
+            if (\count($depends) > 0) {
+                $dependsStr = " depends on " . join(", ", array_map(function ($i) {
+                    return "#" . $i;
+                }, $depends));
+            }
+
+            fwrite(STDOUT, " - #".$index . ' ' . $test->getDisplayName() . $dependsStr . "\n");
+        }
+    }
+
+    public function createDepends(Test $test, array $orders = []): array
+    {
+        $depends = [];
+
+        foreach ($test->getParents() as $parentTest) {
+            $depends = array_merge($depends, $this->createDepends($parentTest, $orders));
+        }
+
+        if (\array_key_exists($test->getDisplayName(), $orders)) {
+            $depends[] = $orders[$test->getDisplayName()];
+        }
+
+        return $depends;
+    }
+}


### PR DESCRIPTION
This allow to debug in which order test has been in success or failure, this allow to better debug case when some tests are failing if executed before or after another one which can happens in a slower / faster / different environment