### PR TITLE
Maintenance update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: ["8.3"]
+                php-version: ["8.3", "8.4"]
                 composer-flags: [""]
                 name: [""]
                 include:

--- a/composer.json
+++ b/composer.json
@@ -34,12 +34,12 @@
         "symfony/console": "^5.4 || ^6.4 || ^7.0",
         "symfony/finder": "^5.4 || ^6.4 || ^7.0"
     },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.72.0",
+        "phpstan/phpstan": "^2.1.8"
+    },
     "suggest": {
         "amphp/http-client": "To use the web test case trait"
-    },
-    "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.53.0",
-        "phpstan/phpstan": "^1.10.67"
     },
     "conflict": {
         "amphp/http-client": "<5.0.1",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "amphp/amp": "^3.0",
         "amphp/http-client": "^v5.0.1",
         "amphp/sync": "^2.0",
-        "bovigo/assert": "^7.0",
+        "bovigo/assert": "^7.0 || ^8.0",
         "symfony/console": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0 || ^7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
         "amphp/http-client": "^v5.0.1",
         "amphp/sync": "^2.0",
         "bovigo/assert": "^7.0 || ^8.0",
-        "symfony/console": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/finder": "^4.4 || ^5.0 || ^6.0 || ^7.0"
+        "symfony/console": "^5.4 || ^6.4 || ^7.0",
+        "symfony/finder": "^5.4 || ^6.4 || ^7.0"
     },
     "suggest": {
         "amphp/http-client": "To use the web test case trait"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,7 @@ parameters:
     level: max
     paths:
         - src/
+    ignoreErrors:
+        - identifier: trait.unused
     excludePaths:
         - src/Assert/Assertion.php

--- a/src/HttpClient/ApiResponse.php
+++ b/src/HttpClient/ApiResponse.php
@@ -12,7 +12,7 @@ use Amp\Http\HttpResponse;
 class ApiResponse extends HttpResponse implements \ArrayAccess
 {
     /**
-     * @var array<string, mixed>|null
+     * @var array<string|int, mixed>|null
      */
     private mixed $data = null;
 

--- a/src/Output/PhpUnitAlike.php
+++ b/src/Output/PhpUnitAlike.php
@@ -94,21 +94,19 @@ class PhpUnitAlike implements OutputInterface
     {
         fwrite(STDOUT, $step + 1 .') '.$test->getDisplayName()." failed\n");
 
-        if ($failure instanceof \Throwable) {
-            fwrite(STDOUT, "\n");
-            fwrite(STDOUT, get_class($failure).': '.$failure->getMessage().' at '.$failure->getFile().':'.$failure->getLine()."\n");
-            fwrite(STDOUT, "\n");
-            $trace = $failure->getTrace();
+        fwrite(STDOUT, "\n");
+        fwrite(STDOUT, get_class($failure).': '.$failure->getMessage().' at '.$failure->getFile().':'.$failure->getLine()."\n");
+        fwrite(STDOUT, "\n");
+        $trace = $failure->getTrace();
 
-            for ($i = 0, $count = min(\count($trace), self::MAX_TRACE); $i < $count; ++$i) {
-                $class = isset($trace[$i]['class']) ? $trace[$i]['class'] : '';
-                $type = isset($trace[$i]['type']) ? $trace[$i]['type'] : '';
-                $function = $trace[$i]['function'];
-                $file = isset($trace[$i]['file']) ? $trace[$i]['file'] : 'n/a';
-                $line = isset($trace[$i]['line']) ? $trace[$i]['line'] : 'n/a';
+        for ($i = 0, $count = min(\count($trace), self::MAX_TRACE); $i < $count; ++$i) {
+            $class = isset($trace[$i]['class']) ? $trace[$i]['class'] : '';
+            $type = isset($trace[$i]['type']) ? $trace[$i]['type'] : '';
+            $function = $trace[$i]['function'];
+            $file = isset($trace[$i]['file']) ? $trace[$i]['file'] : 'n/a';
+            $line = isset($trace[$i]['line']) ? $trace[$i]['line'] : 'n/a';
 
-                fwrite(STDOUT, sprintf("#%s %s%s%s() at %s:%s\n", $i, $class, $type, $function, $file, $line));
-            }
+            fwrite(STDOUT, sprintf("#%s %s%s%s() at %s:%s\n", $i, $class, $type, $function, $file, $line));
         }
 
         fwrite(STDOUT, "\n");

--- a/src/Report/JUnitReport.php
+++ b/src/Report/JUnitReport.php
@@ -9,7 +9,7 @@ use bovigo\assert\AssertionFailure;
 final class JUnitReport
 {
     public function __construct(
-        private readonly string $filename
+        private readonly string $filename,
     ) {
     }
 

--- a/src/Runner/PoolRunner.php
+++ b/src/Runner/PoolRunner.php
@@ -26,7 +26,7 @@ class PoolRunner
     public function __construct(
         private HttpClientConfiguration $defaultHttpConfiguration,
         private TestWorkflow $workflow,
-        int $concurrency = 10
+        int $concurrency = 10,
     ) {
         $this->semaphore = new LocalSemaphore($concurrency);
     }

--- a/src/TestSuite.php
+++ b/src/TestSuite.php
@@ -20,7 +20,7 @@ final class TestSuite
      * @param \ReflectionClass<T> $reflectionClass
      */
     public function __construct(
-        public readonly \ReflectionClass $reflectionClass
+        public readonly \ReflectionClass $reflectionClass,
     ) {
     }
 


### PR DESCRIPTION
- **Add support for PHP 8.4**
- **Allow bovigo/assert ^8.0**
- **Drop support for really EOL SF version <5.4, 6.0, 6.1, 6.2, 6.3**
- **update php-cs-fixer and phpstan**
